### PR TITLE
Proposal: change to _event avoid kw clash

### DIFF
--- a/src/structlog/_log_levels.py
+++ b/src/structlog/_log_levels.py
@@ -160,7 +160,7 @@ def _make_filtering_bound_logger(min_level: int) -> type[FilteringBoundLogger]:
 
         name = _LEVEL_TO_NAME[level]
 
-        def meth(self: Any, event: str, *args: Any, **kw: Any) -> Any:
+        def meth(self: Any, _event: str, *args: Any, **kw: Any) -> Any:
             if not args:
                 return self._proxy_to_logger(name, event, **kw)
 


### PR DESCRIPTION
# Summary
The current `meth` signature could create a clash with provided KW arguments.
In my case, I was trying to log out an AWS Lambda invocation event:
```py
logger.info("handle", event=event)
```
Which resulted in 
`TypeError: meth() got multiple values for argument 'event'`

The idea is to somehow avoid clashes, e.g. adding an underscore in front.

# Pull Request Check List
Haven't done any of the below yet.
I understand this might be a major change in the API, perhaps not something easy to achieve.
At this stage, I'm just letting maintainers know about this issue and brainstorm a possible solution.

- [ ] Added **tests** for changed code.
    - The CI fails with less than 100% coverage.
- [ ] **New APIs** are added to [`api.py`](https://github.com/hynek/structlog/blob/main/tests/typing/api.py).
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
      Find the appropriate next version in our [`__init__.py`](https://github.com/hynek/structlog/blob/main/src/structlog/__init__.py) file.
- [ ] Documentation in `.rst` and `.md` files is written using [**semantic newlines**](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) are documented in the [**changelog**](https://github.com/hynek/structlog/blob/main/CHANGELOG.md).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.
